### PR TITLE
Install correct golang-migrate version when testing with go modules disabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,13 @@ run-cdb-migrations: migrate-check-deps check-cdb-env
 migrate-check-deps:
 	@if [ -z `which migrate` ]; then \
 		echo "[go get] installing golang-migrate cmd with cockroachdb support";\
-		go get -tags 'cockroachdb postgres' -u github.com/golang-migrate/migrate/v4/cmd/migrate;\
+		if [ "${GO111MODULE}" = "off" ]; then \
+			echo "[go get] installing github.com/golang-migrate/migrate/cmd/migrate"; \
+			go get -tags 'cockroachdb postgres' -u github.com/golang-migrate/migrate/cmd/migrate;\
+		else \
+			echo "[go get] installing github.com/golang-migrate/migrate/v4/cmd/migrate"; \
+			go get -tags 'cockroachdb postgres' -u github.com/golang-migrate/migrate/v4/cmd/migrate;\
+		fi \
 	fi
 
 


### PR DESCRIPTION
This fixes an issue when running the CI tests with go modules disabled
where go get cannot find the correct golang-migrate version thus causing
the CI tests to fail.