### PR TITLE
Ensure that locks used by the in-memory indexer store are always unlocked

### DIFF
--- a/Chapter06/textindexer/store/memory/bleve.go
+++ b/Chapter06/textindexer/store/memory/bleve.go
@@ -64,6 +64,8 @@ func (i *InMemoryBleveIndexer) Index(doc *index.Document) error {
 	key := dcopy.LinkID.String()
 
 	i.mu.Lock()
+	defer i.mu.Unlock()
+
 	// If updating, preserve existing PageRank score
 	if orig, exists := i.docs[key]; exists {
 		dcopy.PageRank = orig.PageRank
@@ -74,7 +76,6 @@ func (i *InMemoryBleveIndexer) Index(doc *index.Document) error {
 	}
 
 	i.docs[key] = dcopy
-	i.mu.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
This commit fixes a bug in the Index() method implementation of the in-memory indexer store where an error would cause the method to return while still holding a lock.

Fixes #16 